### PR TITLE
feat: rename veldyne_driver and velodyne_pointcloud package name

### DIFF
--- a/common_awsim_sensor_launch/package.xml
+++ b/common_awsim_sensor_launch/package.xml
@@ -9,9 +9,9 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>velodyne_driver</exec_depend>
+  <exec_depend>awf_velodyne_driver</exec_depend>
   <exec_depend>velodyne_monitor</exec_depend>
-  <exec_depend>velodyne_pointcloud</exec_depend>
+  <exec_depend>awf_velodyne_pointcloud</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
## Description
In order to create debian package, we are renaming velodyne driver packages by adding prefix `awf_` so that we can avoid conflict with the upstream packages.

This PR will point to the branch with renamed packages.

Related Issue:
https://github.com/autowarefoundation/autoware/issues/3222#issuecomment-1475656867
<!-- Write a brief description of this PR. -->

## Notes to reviewers
This should be merged with other PRs for launch files:
- autoware.repos: https://github.com/autowarefoundation/autoware/pull/3492
- sample_sensor_kit_launch: https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/58

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
