### PR TITLE
fix: restore timeout_sec

### DIFF
--- a/awsim_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
+++ b/awsim_sensor_kit_launch/launch/pointcloud_preprocessor.launch.py
@@ -47,6 +47,7 @@ def launch_setup(context, *args, **kwargs):
                 "output_frame": LaunchConfiguration("base_frame"),
                 "input_twist_topic_type": "twist",
                 "publish_synchronized_pointcloud": True,
+                "timeout_sec": 0.01,
             }
         ],
         extra_arguments=[


### PR DESCRIPTION
## Description

Currently, AWSIM publishes only the top lidar data. As a result, the concatenate node waits for the left and right lidar data until it reaches the timeout.

In a previous change (https://github.com/tier4/awsim_sensor_kit_launch/pull/22), the `timeout_sec` argument was removed, which changed the actual value of `timeout_sec` from 0.01 to 0.033. This has caused performance degradation in `autoware_ekf_localizer` due to slower lidar data publishing.

This pull request addresses the issue by restoring the appropriate timeout setting.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
